### PR TITLE
refactor: login controller clean up for readability

### DIFF
--- a/api/controllers/auth.js
+++ b/api/controllers/auth.js
@@ -17,40 +17,27 @@ const login = async (req, res) => {
   }
   const user = await UserModel.findOne({ username });
   if (!user) {
-    throw new UnauthenticatedError("Invalid Credentials");
+    throw new UnauthenticatedError("Invalid Username...");
   }
   const isPasswordCorrect = await user.comparePassword(password);
   if (!isPasswordCorrect) {
-    throw new UnauthenticatedError("Invalid Credentials");
+    throw new UnauthenticatedError("Invalid Password...");
   }
-  // const token = user.createJWT();
-
-  // return res
-  //   .cookie("token", token, {
-  //     sameSite: "None",
-  //     secure: true,
-  //   })
-  //   .json({
-  //     id: user._id,
-  //     username,
-  //   });
-
-  if (isPasswordCorrect) {
-    jwt.sign(
-      { username, id: user._id },
-      process.env.JWT_SECRET,
-      {},
-      (err, token) => {
-        if (err) throw err;
-        res.cookie("token", token).json({
-          id: user._id,
-          username,
-        });
-      }
-    );
-  } else {
-    res.status(400).json("wrong credentials");
+  /** Error when implementing `createJWT()`
+   * ! 'author' property  in response breaks
+   */
+  const token = await jwt.sign(
+    { username, id: user._id },
+    process.env.JWT_SECRET,
+    {}
+  );
+  if (!token) {
+    throw new Error("JWT sigining failed...");
   }
+  res.cookie("token", token, { sameSite: "None", secure: true }).json({
+    id: user.id,
+    username,
+  });
 };
 
 const profile = async (req, res) => {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1,6 +1,6 @@
 const mongoose = require("mongoose");
 const bcrypt = require("bcryptjs");
-// const jwt = require("jsonwebtoken");
+const jwt = require("jsonwebtoken");
 
 const UserSchema = new mongoose.Schema({
   username: {
@@ -21,16 +21,16 @@ UserSchema.pre("save", async function () {
   this.password = await bcrypt.hash(this.password, salt);
 });
 
-// UserSchema.methods.createJWT = function () {
-//   return jwt.sign(
-//     { userId: this._id, username: this.username },
-//     process.env.JWT_SECRET,
-//     {},
-//     {
-//       expiresIn: process.env.JWT_LIFETIME,
-//     }
-//   );
-// };
+UserSchema.methods.createJWT = function () {
+  return jwt.sign(
+    { userId: this._id, username: this.username },
+    process.env.JWT_SECRET,
+    {},
+    {
+      expiresIn: process.env.JWT_LIFETIME,
+    }
+  );
+};
 
 UserSchema.methods.comparePassword = async function (candidatePassword) {
   const isMatch = await bcrypt.compare(candidatePassword, this.password);


### PR DESCRIPTION
### refactor: login controller clean up
- clean up login controller 
- un-comment `createJWT()` because it's need for registration() controller